### PR TITLE
[feat] 관광지 추천 api

### DIFF
--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/config/AppConfig.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/config/AppConfig.java
@@ -1,6 +1,7 @@
 package JejuDorang.JejuDorang.config;
 
 import JejuDorang.JejuDorang.auth.dto.KakaoConfig;
+import JejuDorang.JejuDorang.tourspot.dto.TourSpotConfig;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,5 +18,15 @@ public class AppConfig {
         kakaoConfig.setRedirectUri(dotenv.get("KAKAO_REDIRECT_URI"));
 
         return (kakaoConfig);
+    }
+
+    @Bean
+    public TourSpotConfig tourSpotConfig() {
+        Dotenv dotenv = Dotenv.load();
+
+        TourSpotConfig tourSpotConfig = new TourSpotConfig();
+        tourSpotConfig.setServiceKey(dotenv.get("TOUR_API_KEY"));
+
+        return (tourSpotConfig);
     }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
@@ -1,0 +1,42 @@
+package JejuDorang.JejuDorang.tourspot.controller;
+
+import JejuDorang.JejuDorang.tourspot.dto.TourSpotConfig;
+import JejuDorang.JejuDorang.tourspot.dto.TourSpotRequestDto;
+import JejuDorang.JejuDorang.tourspot.service.TourSpotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tourspot")
+@RequiredArgsConstructor
+public class TourSpotController {
+
+    private final TourSpotService tourSpotService;
+
+    @Autowired
+    private TourSpotConfig tourSpotConfig;
+
+    @GetMapping("/recommendation")
+    public ResponseEntity<Void> tourSpotRecommend
+            (@RequestBody TourSpotRequestDto tourSpotRequestDto) {
+
+        String requestUrl
+                = "http://apis.data.go.kr/B551011/KorService1/locationBasedList1"
+                + "?MobileOS=ETC"
+                + "&MobileApp=JEJU-DORANG"
+                + "&mapX=" + tourSpotRequestDto.getMapX()
+                + "&mapY=" + tourSpotRequestDto.getMapY()
+                + "&radius=15000"
+                + "&serviceKey=" + tourSpotConfig.getServiceKey()가
+                + "&_type=json";
+
+        tourSpotService.getTourSpot(requestUrl);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
@@ -32,7 +32,7 @@ public class TourSpotController {
                 + "&mapX=" + tourSpotRequestDto.getMapX()
                 + "&mapY=" + tourSpotRequestDto.getMapY()
                 + "&radius=15000"
-                + "&serviceKey=" + tourSpotConfig.getServiceKey()가
+                + "&serviceKey=" + tourSpotConfig.getServiceKey()
                 + "&_type=json";
 
         tourSpotService.getTourSpot(requestUrl);

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
@@ -2,6 +2,7 @@ package JejuDorang.JejuDorang.tourspot.controller;
 
 import JejuDorang.JejuDorang.tourspot.dto.TourSpotConfig;
 import JejuDorang.JejuDorang.tourspot.dto.TourSpotRequestDto;
+import JejuDorang.JejuDorang.tourspot.dto.TourSpotResponseDto;
 import JejuDorang.JejuDorang.tourspot.service.TourSpotService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/tourspot")
@@ -22,7 +25,7 @@ public class TourSpotController {
     private TourSpotConfig tourSpotConfig;
 
     @GetMapping("/recommendation")
-    public ResponseEntity<Void> tourSpotRecommend
+    public ResponseEntity<List<TourSpotResponseDto>> tourSpotRecommend
             (@RequestBody TourSpotRequestDto tourSpotRequestDto) {
 
         String requestUrl
@@ -36,8 +39,8 @@ public class TourSpotController {
                 + "&contentTypeId=12"
                 + "&_type=json";
 
-        tourSpotService.getTourSpot(requestUrl);
+        List<TourSpotResponseDto> tourSpotResponseDtos = tourSpotService.getTourSpot(requestUrl);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(tourSpotResponseDtos);
     }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/controller/TourSpotController.java
@@ -33,6 +33,7 @@ public class TourSpotController {
                 + "&mapY=" + tourSpotRequestDto.getMapY()
                 + "&radius=15000"
                 + "&serviceKey=" + tourSpotConfig.getServiceKey()
+                + "&contentTypeId=12"
                 + "&_type=json";
 
         tourSpotService.getTourSpot(requestUrl);

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotConfig.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotConfig.java
@@ -1,0 +1,9 @@
+package JejuDorang.JejuDorang.tourspot.dto;
+
+import lombok.Data;
+
+@Data
+public class TourSpotConfig {
+
+    private String serviceKey;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotRequestDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotRequestDto.java
@@ -1,0 +1,14 @@
+package JejuDorang.JejuDorang.tourspot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TourSpotRequestDto {
+
+    private String mapX;
+    private String mapY;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotResponseDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/dto/TourSpotResponseDto.java
@@ -1,0 +1,15 @@
+package JejuDorang.JejuDorang.tourspot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TourSpotResponseDto {
+
+    private String title;
+    private String address;
+    private String image;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
@@ -1,0 +1,27 @@
+package JejuDorang.JejuDorang.tourspot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Service
+@RequiredArgsConstructor
+public class TourSpotService {
+
+    public void getTourSpot(String requestUrl) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            URI uri = new URI(requestUrl);
+            ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
+
+
+            System.out.println(response.getBody());
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
@@ -1,27 +1,53 @@
 package JejuDorang.JejuDorang.tourspot.service;
 
+import JejuDorang.JejuDorang.tourspot.dto.TourSpotResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TourSpotService {
 
-    public void getTourSpot(String requestUrl) {
-        RestTemplate restTemplate = new RestTemplate();
+    public List<TourSpotResponseDto> getTourSpot(String requestUrl) {
+
+        List<TourSpotResponseDto> tourSpotResponseDtos = new ArrayList<>();
+
         try {
+            RestTemplate restTemplate = new RestTemplate();
             URI uri = new URI(requestUrl);
             ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
 
+            // JSON 파싱을 위한 ObjectMapper 생성
+            ObjectMapper objectMapper = new ObjectMapper();
 
-            System.out.println(response.getBody());
-        } catch (URISyntaxException e) {
+            // JSON 문자열을 JsonNode 객체로 변환
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+
+            // body -> items
+            JsonNode itemsNode = rootNode.path("response").path("body").path("items").path("item");
+
+            for (JsonNode itemNode : itemsNode) {
+                // 각 항목의 필드 값 추출
+                String title = itemNode.path("title").asText();
+                String address = itemNode.path("addr1").asText();
+                String image = itemNode.path("firstimage").asText();
+
+                tourSpotResponseDtos.add(new TourSpotResponseDto(
+                        title, address, image ));
+            }
+
+        } catch (Exception e) {
             e.printStackTrace();
         }
+
+        return tourSpotResponseDtos;
     }
 }


### PR DESCRIPTION
 ## 📌 개요
  - 위치기반 관광지 조회 api에 <위도, 경도>로 요청하여 받아온 데이터를 가공해서 프론트에게 반환하는 코드를 작성했습니다.
  - .env 파일에 TOUR_API_KEY 추가해주세요! (노션에 추가해놓았습니다)

 ## 💻 작업사항 
  - TourSpotRequestDto 에 위도, 경도를 받아옵니다
  - 요청 url에 필요한 정보들 넣어서 tour api에 요청하고 반환된  데이터를 파싱합니다
  - title이 관광지명, addr1이 주소, firstimage가 관광지 사진입니다
  - url을 그대로 담아서 요청하니 api key 인코딩 문제??가 생겨서 등록되지 않은 key 에러가 뜨더라고요. 그래서 URI 객체에 넣어서 요청하는 방식으로 진행했습니다.

 ## 💡Issue 번호
 - close #18 
