### PR TITLE
[feat] 업적 인증 일기

### DIFF
--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/controller/DiaryController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/controller/DiaryController.java
@@ -19,6 +19,9 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
+    // 일기 작성
+    // 1. isAchievement = true -> achievementId 확인해서 달성률 증가 + 일기 저장
+    // 2. isAchievement = false -> 일기 저장
     @PostMapping("/diary")
     public ResponseEntity<Void> createDiary(@RequestBody DiaryRequestDto diaryRequestDto, @Login Member member) {
 

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/dto/DiaryRequestDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/dto/DiaryRequestDto.java
@@ -23,5 +23,9 @@ public class DiaryRequestDto {
     @JsonProperty("secret")
     private SecretType secret;
 
+    private Boolean isAchievement;
+
+    private Long achievementId;
+
     private List<TagDto> tagList;
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/service/DiaryService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/service/DiaryService.java
@@ -60,7 +60,7 @@ public class DiaryService {
             if (achievementCnt < max) {
                 memberAchievement.incAchievementCnt();
             }
-            if (achievementCnt == max) {
+            if (memberAchievement.getAchievementCnt() == max) {
                 memberAchievement.updateAchievementStatus();
             }
             memberAchievementRepository.save(memberAchievement);

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/MemberAchievement.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/MemberAchievement.java
@@ -32,4 +32,12 @@ public class MemberAchievement {
 	private AchievementStatus achievementStatus;
 
 	private long achievementCnt;
+
+	public void incAchievementCnt() {
+		this.achievementCnt++;
+	}
+
+	public void updateAchievementStatus() {
+		this.achievementStatus = AchievementStatus.DONE;
+	}
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/MemberAchievement.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/MemberAchievement.java
@@ -2,13 +2,7 @@ package JejuDorang.JejuDorang.member.data;
 
 import JejuDorang.JejuDorang.achievement.data.Achievement;
 import JejuDorang.JejuDorang.achievement.enums.AchievementStatus;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -29,6 +23,7 @@ public class MemberAchievement {
 	@JoinColumn(name = "achievement_id")
 	private Achievement achievement;
 
+	@Enumerated(EnumType.STRING)
 	private AchievementStatus achievementStatus;
 
 	private long achievementCnt;

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/repository/MemberAchievementRepository.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/repository/MemberAchievementRepository.java
@@ -1,5 +1,6 @@
 package JejuDorang.JejuDorang.member.repository;
 
+import JejuDorang.JejuDorang.achievement.data.Achievement;
 import JejuDorang.JejuDorang.achievement.enums.AchievementStatus;
 import JejuDorang.JejuDorang.member.data.Member;
 import JejuDorang.JejuDorang.member.data.MemberAchievement;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface MemberAchievementRepository extends JpaRepository<MemberAchievement, Long> {
 
     List<MemberAchievement> findByMemberAndAchievementStatus(Member member, AchievementStatus achievementStatus);
+    MemberAchievement findByMemberAndAchievement(Member member, Achievement achievement);
 }


### PR DESCRIPTION
 ## 📌 개요
  - 업적 인증하기를 통해 작성한 일기는 업적 달성률을 조정해줘야 한다.
  - 
 ## 💻 작업사항
  - 일기 작성 요청이 오면 isAchievement 필드를 확인한다
  - 만약, isAchievement = true이면 achievementId를 확인한다.
  - 해당 업적의 최대 달성치랑 현재 달성치를 비교해 현재 달성치를 증가해준다.
  - 만약 최대 달성치와 현재 달성치가 같아지면 achievementStatus를 DONE으로 바꿔준다.
  - 
  -  ## 💡Issue 번호
 - close #51 
