### PR TITLE
[feat] 좋아요 취소 추가

### DIFF
--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/controller/LikeController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/controller/LikeController.java
@@ -17,17 +17,27 @@ public class LikeController {
 
     private final LikeService likeService;
 
+    // 댓글 좋아요
     @PostMapping("/comment/{commentId}")
     public ResponseEntity<Void> createLikeComment(@PathVariable Long commentId, @Login Member member) {
 
-        likeService.createLikeComment(commentId, member);
+        boolean alreayLike = likeService.alreadyLikeComment(commentId, member.getId());
+        if (!alreayLike)
+            likeService.createLikeComment(commentId, member);
+        else
+            likeService.deleteLikeComment(commentId, member);
         return ResponseEntity.ok().build();
     }
 
+    // 일기 좋아요
     @PostMapping("/diary/{diaryId}")
     public ResponseEntity<Void> createLikeDiary(@PathVariable Long diaryId, @Login Member member) {
 
-        likeService.createLikeDiary(diaryId, member);
+        boolean alreadyLike = likeService.alreadyLikeDiary(diaryId, member.getId());
+        if (!alreadyLike)
+            likeService.createLikeDiary(diaryId, member);
+        else
+            likeService.deleteLikeComment(diaryId, member);
         return ResponseEntity.ok().build();
     }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/repository/LikeCommentRepository.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/repository/LikeCommentRepository.java
@@ -1,6 +1,7 @@
 package JejuDorang.JejuDorang.like.repository;
 
 import JejuDorang.JejuDorang.like.data.LikeComment;
+import JejuDorang.JejuDorang.member.data.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface LikeCommentRepository extends JpaRepository<LikeComment, Long> 
 
     List<LikeComment> findAllByCommentId(Long commentId);
     boolean existsByCommentIdAndMemberId(Long commentId, Long memberId);
+
+    LikeComment findByCommentIdAndMember(Long commentId, Member member);
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/repository/LikeDiaryRepository.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/repository/LikeDiaryRepository.java
@@ -1,9 +1,12 @@
 package JejuDorang.JejuDorang.like.repository;
 
 import JejuDorang.JejuDorang.like.data.LikeDiary;
+import JejuDorang.JejuDorang.member.data.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeDiaryRepository extends JpaRepository<LikeDiary, Long> {
 
     boolean existsByDiaryIdAndMemberId(Long diaryId, Long memberId);
+
+    LikeDiary findByDiaryIdAndMember(Long diaryId, Member member);
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/service/LikeService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/like/service/LikeService.java
@@ -40,6 +40,13 @@ public class LikeService {
         likeCommentRepository.save(likeComment);
     }
 
+    // 댓글 좋아요 취소
+    public void deleteLikeComment(Long commentId, Member member) {
+
+        LikeComment likeComment = likeCommentRepository.findByCommentIdAndMember(commentId, member);
+        likeCommentRepository.delete(likeComment);
+    }
+
     // 댓글 좋아요 수 계산
     public int countLikeComment(Long commentId) {
 
@@ -67,6 +74,13 @@ public class LikeService {
                 .date(LocalDateTime.now())
                 .build();
         likeDiaryRepository.save(likeDiary);
+    }
+
+    // 일기 좋아요 취소
+    public void deleteLikeDiary(Long diaryId, Member member) {
+
+        LikeDiary likeDiary = likeDiaryRepository.findByDiaryIdAndMember(diaryId, member);
+        likeDiaryRepository.delete(likeDiary);
     }
 
     // 현재 유저가 특정 일기에 좋아요를 눌렀는지 여부


### PR DESCRIPTION
 ## 📌 개요
  - 댓글, 일기 좋아요 취소 api 추가
 ## 💻 작업사항
  - 해당 댓글, 일기에 본인이 이미 좋아요를 눌렀다면 한번 더 눌렀을때 삭제해줌
 ## 💡Issue 번호
 - close #52 
