### PR TITLE
[feat] 업적 id 처리

### DIFF
--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/achievement/dto/AchievementDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/achievement/dto/AchievementDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 public class AchievementDto {
+	private final Long achievementId;
 	private final String achievementIcon;
 	private final String achievementName;
 	private final String achievementComment;

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/controller/CharacterController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/controller/CharacterController.java
@@ -1,13 +1,14 @@
 package JejuDorang.JejuDorang.character.controller;
 
 import JejuDorang.JejuDorang.auth.argumentresolver.Login;
+import JejuDorang.JejuDorang.character.dto.ItemRequestDto;
 import JejuDorang.JejuDorang.character.dto.ItemResponseDto;
 import JejuDorang.JejuDorang.character.service.CharacterService;
+import JejuDorang.JejuDorang.diary.dto.DiaryDetailResponseDto;
 import JejuDorang.JejuDorang.member.data.Member;
 import lombok.AllArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
@@ -16,9 +17,17 @@ public class CharacterController {
 
     private final CharacterService characterService;
 
+    // 소유하고 있는 아이템 반환
     @GetMapping("/items")
-    public ItemResponseDto getItem(@Login Member member) {
+    public ResponseEntity<ItemResponseDto> getItem(@Login Member member) {
         ItemResponseDto responseDto = characterService.getItems(member);
-        return responseDto;
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 아이템 장착하기
+    @PostMapping("/items")
+    public ResponseEntity<Void> putItem(@Login Member member, @RequestBody ItemRequestDto itemRequestDto) {
+        characterService.putItem(member, itemRequestDto);
+        return  ResponseEntity.ok().build();
     }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/data/Character.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/data/Character.java
@@ -25,12 +25,6 @@ public class Character {
     private int itemImage;
     private int petImage;
 
-    public Character(int backgroundImage, int itemImage, int petImage) {
-        this.backgroundImage = backgroundImage;
-        this.itemImage = itemImage;
-        this.petImage = petImage;
-    }
-
     @OneToOne
    @JoinColumn(name = "member_id")
    private Member member;
@@ -46,4 +40,16 @@ public class Character {
     @OneToMany(mappedBy = "character")
     @Builder.Default
     private List<StuffItem> stuffItems = new ArrayList<>();
+
+    public Character(int backgroundImage, int itemImage, int petImage) {
+        this.backgroundImage = backgroundImage;
+        this.itemImage = itemImage;
+        this.petImage = petImage;
+    }
+
+    public void updateItem(int backgroundImage, int itemImage, int petImage) {
+        this.backgroundImage = backgroundImage;
+        this.itemImage = itemImage;
+        this.petImage = petImage;
+    }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/dto/ItemRequestDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/dto/ItemRequestDto.java
@@ -1,0 +1,15 @@
+package JejuDorang.JejuDorang.character.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemRequestDto {
+
+    private int backgroundItem;
+    private int stuffItem;
+    private int petItem;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/service/CharacterService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/character/service/CharacterService.java
@@ -1,6 +1,7 @@
 package JejuDorang.JejuDorang.character.service;
 
 import JejuDorang.JejuDorang.character.data.Character;
+import JejuDorang.JejuDorang.character.dto.ItemRequestDto;
 import JejuDorang.JejuDorang.character.dto.ItemResponseDto;
 import JejuDorang.JejuDorang.character.repository.CharacterRepository;
 import JejuDorang.JejuDorang.item.data.BackgroundItem;
@@ -55,5 +56,16 @@ public class CharacterService {
 
         // DTO 반환
         return itemResponseDto;
+    }
+
+    // 아이템 장착하기
+    public void putItem(Member member, ItemRequestDto itemRequestDto) {
+
+        Character character = characterRepository.findByMember(member);
+        character.updateItem(
+                itemRequestDto.getBackgroundItem(),
+                itemRequestDto.getStuffItem(),
+                itemRequestDto.getPetItem());
+        characterRepository.save(character);
     }
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/dto/DiaryRequestDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/dto/DiaryRequestDto.java
@@ -23,8 +23,6 @@ public class DiaryRequestDto {
     @JsonProperty("secret")
     private SecretType secret;
 
-    private Boolean isAchievement;
-
     private Long achievementId;
 
     private List<TagDto> tagList;

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/service/DiaryService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/diary/service/DiaryService.java
@@ -57,10 +57,9 @@ public class DiaryService {
     // 일기 작성
     public void createDiary(DiaryRequestDto diaryRequestDto, Member member) {
 
-        // isAchievement 확인
-        Boolean isAchievement = diaryRequestDto.getIsAchievement();
-        if (isAchievement == true) {
-            Long achievementId = diaryRequestDto.getAchievementId();
+        // 업적 일기, 일반 일기 구분
+        Long achievementId = diaryRequestDto.getAchievementId();
+        if (achievementId != 0) {
             Achievement achievement = achievementRepository.findById(achievementId)
                     .orElseThrow(()->new IllegalArgumentException("존재하지 않는 업적" ));
             MemberAchievement memberAchievement = memberAchievementRepository.findByMemberAndAchievement(member, achievement);

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/streak/service/StreakService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/streak/service/StreakService.java
@@ -44,7 +44,7 @@ public class StreakService {
 
     // 멤버의 스트릭 반환
     public List<StreakResponseDto> getStreaks(Member member, String year, String month) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate startDate = LocalDate.parse(year + "-" + month + "-01", formatter);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()).plusDays(1);
 

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/tourspot/service/TourSpotService.java
@@ -85,6 +85,7 @@ public class TourSpotService {
 
             // AchievementDto 생성
             AchievementDto achievementDto = new AchievementDto(
+                    achievement.getId(),
                     achievement.getImage(),
                     achievement.getName(),
                     achievement.getContent(),


### PR DESCRIPTION
 ## 📌 개요
  - 도랑이 아이템 관련해서 추가할 부분과 스트릭 파싱 부분

 ## 💻 작업사항
  - 일기 작성 완료 부분에서 isAchievement 빼고, achievementId가 0 이면 일반 일기로 구분하도록 수정했습니다.
  - 도랑이 놀거리 추천에서 achievementId도 함께 반환하도록 수정했습니다.
  - 도랑이 아이템 장착 api 추가했습니다. character 필드에 장착한 아이템 인덱스 저장합니다.
  - 스트릭 parsing format에 -d day 추가해줬습니다.

 ## 💡Issue 번호
 - close #60 
