### PR TITLE
[feat] 회원정보 api 추가 (프로필 사진, 상태 메시지)

### DIFF
--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/controller/MemberController.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package JejuDorang.JejuDorang.member.controller;
 
 import java.util.List;
 
+import JejuDorang.JejuDorang.member.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +19,6 @@ import JejuDorang.JejuDorang.diary.dto.DiaryListResponseDTO;
 import JejuDorang.JejuDorang.diary.dto.MyDiaryDetailResponseDto;
 import JejuDorang.JejuDorang.diary.enums.SecretType;
 import JejuDorang.JejuDorang.member.data.Member;
-import JejuDorang.JejuDorang.member.dto.MemberDetailResponseDto;
-import JejuDorang.JejuDorang.member.dto.MemberEmailDto;
-import JejuDorang.JejuDorang.member.dto.MemberNameDto;
 import JejuDorang.JejuDorang.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -104,6 +102,18 @@ public class MemberController {
 	@PatchMapping("/email")
 	public ResponseEntity<Void> updateEmail(@RequestBody @Valid MemberEmailDto memberEmailDto, @Login Member member) {
 		memberService.updateEmail(memberEmailDto.getMemberEmail(), member);
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/image")
+	public ResponseEntity<Void> updateImage(@RequestBody MemberImageDto memberImageDto, @Login Member member) {
+		memberService.updateImage(memberImageDto.getMemberImage(), member);
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/content")
+	public ResponseEntity<Void> updateImage(@RequestBody MemberContentDto memberContentDto, @Login Member member) {
+		memberService.updateContent(memberContentDto.getMemberContent(), member);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/Member.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/data/Member.java
@@ -138,4 +138,12 @@ public class Member implements UserDetails {
 	public void setCharacter(Character character) {
 		this.character = character;
 	}
+
+	public void updateImage(String image) {
+		this.image = image;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
 }

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/dto/MemberContentDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/dto/MemberContentDto.java
@@ -1,0 +1,13 @@
+package JejuDorang.JejuDorang.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberContentDto {
+
+    private String memberContent;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/dto/MemberImageDto.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/dto/MemberImageDto.java
@@ -1,0 +1,13 @@
+package JejuDorang.JejuDorang.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberImageDto {
+
+    private String memberImage;
+}

--- a/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/service/MemberService.java
+++ b/JejuDorang/src/main/java/JejuDorang/JejuDorang/member/service/MemberService.java
@@ -179,4 +179,14 @@ public class MemberService {
     public MemberMainResponseDto getMainPage(Member member) {
         return memberRepository.getMainPage(member);
     }
+
+    public void updateImage(String image, Member member) {
+        member.updateImage(image);
+        memberRepository.save(member);
+    }
+
+    public void updateContent(String content, Member member) {
+        member.updateContent(content);
+        memberRepository.save(member);
+    }
 }


### PR DESCRIPTION
 ## 📌 개요
  - 회원 프로필 사진, 상태 메시지 수정

 ## 💻 작업사항
  - 회원 프로필 사진 수정하는 api 추가 (Patch)
  - 회원 상태 메시지 수정하는 api 추가 (Patch)

 ## 💡Issue 번호
 - close #62 
